### PR TITLE
Update globals.css by giving a stronger CSS Selector on .hidden-nav

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -148,7 +148,8 @@ footer a img {
   z-index: 10;
 }
 
-.hidden-nav {
+/* using stronger CSS selector since .nav also carries "display" property  */
+.nav.hidden-nav {
   display: none !important;
 }
 


### PR DESCRIPTION
There's a CSS property conflict if we only use the CSS Selector ".hidden-nav" because ".nav" also carries the display property (display : flex) so i added a stronger CSS selector to avoid such issue. I believe you met the same issue since i see the !important keyword but !important had no effect on my machine